### PR TITLE
Add redirect for /encryption to v0.15.x documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -33,6 +33,10 @@
       "destination": "/versions/changelog"
     },
     {
+      "source": "/encryption",
+      "destination": "versions/v0.15.x/intro/encryption"
+    },
+    {
       "source": "/service",
       "destination": "/versions/v0.15.x/service/guides/intro/about"
     },


### PR DESCRIPTION
## Summary
- Added redirect rule to map `/encryption` to `versions/v0.15.x/intro/encryption`
- Ensures users accessing the legacy URL are properly redirected to the versioned documentation

## Changes
- Added new redirect entry in `docs.json` redirects array

## Test plan
- [ ] Verify redirect works when accessing `/encryption`
- [ ] Confirm destination page exists at `versions/v0.15.x/intro/encryption`
- [ ] Test that other redirects continue to function properly

🤖 Generated with [Claude Code](https://claude.ai/code)